### PR TITLE
Unify session reset flow and cover with tests

### DIFF
--- a/app/Home.py
+++ b/app/Home.py
@@ -4,16 +4,9 @@ from __future__ import annotations
 import streamlit as st
 
 from app.components.forms import render_sidebar
-from app.state import session_keys as keys
+from app.state.session import handle_full_reset
 from app.utils.cache import load_dag40_cached
 from app.utils.time_windows import current_time_window
-
-
-def _handle_full_reset() -> None:
-    if st.session_state.get(keys.FULL_RESET_FLAG, False):
-        st.session_state.clear()
-        st.session_state[keys.FULL_RESET_FLAG] = False
-        st.rerun()
 
 
 def main() -> None:
@@ -23,7 +16,7 @@ def main() -> None:
         layout="wide",
     )
 
-    _handle_full_reset()
+    handle_full_reset()
 
     st.title("Geração de Notas de Cobrança - Painel de Solicitações")
     st.caption("Solicite a geração de notas por UTD, TURMA e BASE, com validações operacionais de horário.")

--- a/app/state/session.py
+++ b/app/state/session.py
@@ -2,19 +2,22 @@ from __future__ import annotations
 
 import streamlit as st
 
+from app.state import session_keys as keys
 
-SESSION_RESET_KEY = "_do_full_reset"
+
+__all__ = ["handle_full_reset", "trigger_full_reset"]
 
 
 def handle_full_reset() -> None:
     """Clear Streamlit session state when a full reset is requested."""
 
-    if st.session_state.get(SESSION_RESET_KEY, False):
+    if st.session_state.get(keys.FULL_RESET_FLAG, False):
         st.session_state.clear()
-        st.session_state[SESSION_RESET_KEY] = False
+        st.session_state[keys.FULL_RESET_FLAG] = False
+        st.rerun()
 
 
 def trigger_full_reset() -> None:
     """Flag the current session to be fully reset on the next run."""
 
-    st.session_state[SESSION_RESET_KEY] = True
+    st.session_state[keys.FULL_RESET_FLAG] = True

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+streamlit_stub = types.ModuleType("streamlit")
+streamlit_stub.session_state = {}
+
+
+def _noop() -> None:  # pragma: no cover - executed only if a test fails to patch ``st``
+    pass
+
+
+streamlit_stub.rerun = _noop
+sys.modules.setdefault("streamlit", streamlit_stub)
+
+from app.state import session
+from app.state import session_keys as keys
+
+
+class _FakeStreamlit(SimpleNamespace):
+    def __init__(self) -> None:
+        super().__init__(session_state={}, rerun_called=False)
+
+    def rerun(self) -> None:  # pragma: no cover - invoked indirectly
+        self.rerun_called = True
+
+
+def test_trigger_full_reset_sets_flag(monkeypatch):
+    fake_st = _FakeStreamlit()
+    monkeypatch.setattr(session, "st", fake_st)
+
+    session.trigger_full_reset()
+
+    assert fake_st.session_state[keys.FULL_RESET_FLAG] is True
+
+
+def test_handle_full_reset_clears_state_and_reruns(monkeypatch):
+    fake_st = _FakeStreamlit()
+    fake_st.session_state[keys.FULL_RESET_FLAG] = True
+    monkeypatch.setattr(session, "st", fake_st)
+
+    session.handle_full_reset()
+
+    assert fake_st.session_state == {keys.FULL_RESET_FLAG: False}
+    assert fake_st.rerun_called is True
+
+
+def test_handle_full_reset_no_flag(monkeypatch):
+    fake_st = _FakeStreamlit()
+    monkeypatch.setattr(session, "st", fake_st)
+
+    session.handle_full_reset()
+
+    assert fake_st.session_state == {}
+    assert fake_st.rerun_called is False


### PR DESCRIPTION
## Summary
- reuse the session reset helper inside the Streamlit Home entry point
- centralize the reset flag handling around the shared session key constant
- add regression tests that exercise the trigger and reset helpers without a Streamlit dependency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd2d8ab9c88332863c5813b656f3b3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Refactor
  - Centralized app reset logic into a single session management module, ensuring consistent behavior across the app.
  - Startup flow now delegates reset handling to the shared session layer for improved reliability.

- Tests
  - Added comprehensive tests covering session reset triggers, state clearing, and rerun behavior to prevent regressions and ensure predictable resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->